### PR TITLE
Do not use isolated build to get package metadata

### DIFF
--- a/jaraco/packaging/sphinx.py
+++ b/jaraco/packaging/sphinx.py
@@ -27,7 +27,7 @@ def load_config_from_setup(app):
     """
     # for now, assume project root is one level up
     root = os.path.join(app.confdir, '..')
-    meta = load_metadata(root)
+    meta = load_metadata(root, isolated=False)
     app.config.project = meta['Name']
     app.config.version = app.config.release = meta['Version']
     app.config.package_url = meta['Home-page']


### PR DESCRIPTION
Do not use the isolated build to get package metadata via `build`. Using the isolated build unnecessarily creates a virtualenv and reinstalls all package's build dependencies just to get the version number, effectively preventing the documentation from being built offline.  At the same time, it is reasonable to provide the necessary dependencies in the environment nominally used to build documentation.

Fixes #7