### PR TITLE
Add JARACO_PACKAGING_SPHINX_WHEEL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,11 @@ To enable, include 'jaraco.packaging' in your requirements and add
 
     extensions=['jaraco.packaging.sphinx']
 
+The extension by default builds the project in an isolated environment in
+order to extract the metadata. If you need to build the documentation offline,
+you can provide an already built wheel by setting the environment variable
+``JARACO_PACKAGING_SPHINX_WHEEL`` to the path of the existing wheel.
+
 make-tree
 =========
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,14 @@
+import subprocess
+
+import pytest
+
+
+@pytest.fixture
+def static_wheel(tmp_path, monkeypatch):
+    subprocess.check_call(
+        ['pip', 'download', '--no-deps', '--dest', str(tmp_path), 'sampleproject'],
+        stderr=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+    )
+    (wheel,) = tmp_path.iterdir()
+    monkeypatch.setenv('JARACO_PACKAGING_SPHINX_WHEEL', str(wheel))

--- a/jaraco/packaging/sphinx.py
+++ b/jaraco/packaging/sphinx.py
@@ -9,7 +9,7 @@ True
 import os
 import subprocess
 
-from build.util import project_wheel_metadata as load_metadata_from_source
+from build.util import project_wheel_metadata as load_metadata
 from jaraco.context import suppress
 
 try:
@@ -48,7 +48,7 @@ def load_config_from_setup(app):
     """
     # for now, assume project root is one level up
     root = os.path.join(app.confdir, '..')
-    meta = _load_metadata_from_wheel() or load_metadata_from_source(root)
+    meta = _load_metadata_from_wheel() or load_metadata(root)
     app.config.project = meta['Name']
     app.config.version = app.config.release = meta['Version']
     app.config.package_url = meta['Home-page']

--- a/jaraco/packaging/sphinx.py
+++ b/jaraco/packaging/sphinx.py
@@ -36,6 +36,12 @@ def _load_metadata_from_wheel():
     If indicated by an environment variable, expect the metadata
     to be present in a wheel and load it from there, avoiding
     the build process. Ref jaraco/jaraco.packaging#7.
+
+    >>> _load_metadata_from_wheel()
+    >>> getfixture('static_wheel')
+    >>> meta = _load_metadata_from_wheel()
+    >>> meta['Name']
+    'sampleproject'
     """
     wheel = os.environ['JARACO_PACKAGING_SPHINX_WHEEL']
     (dist,) = metadata.distributions(path=[wheel])

--- a/jaraco/packaging/sphinx.py
+++ b/jaraco/packaging/sphinx.py
@@ -8,8 +8,6 @@ True
 
 import os
 import subprocess
-from email import message_from_string as load_metadata_from_wheel
-from zipfile import ZipFile
 
 from build.util import project_wheel_metadata as load_metadata_from_source
 from jaraco.context import suppress
@@ -35,20 +33,13 @@ def setup(app):
 @suppress(KeyError)
 def _load_metadata_from_wheel():
     """
-    If indicated by an environment variable, expect the metadat
+    If indicated by an environment variable, expect the metadata
     to be present in a wheel and load it from there, avoiding
     the build process. Ref jaraco/jaraco.packaging#7.
     """
-    with ZipFile(os.environ['JARACO_PACKAGING_SPHINX_WHEEL']) as wheel:
-        meta = None
-        for name in wheel.namelist():
-            if '.dist-info' in name and name.endswith("METADATA"):
-                return load_metadata_from_wheel(wheel.read(name).decode())
-        if meta is None:
-            raise RuntimeError(
-                "The environment variable JARACO_PACKAGING_SPHINX_WHEEL "
-                "points to a file not containing metadata."
-            )
+    wheel = os.environ['JARACO_PACKAGING_SPHINX_WHEEL']
+    (dist,) = metadata.distributions(path=[wheel])
+    return dist.metadata
 
 
 def load_config_from_setup(app):

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
 	importlib_metadata; python_version < "3.8"
 	# virtualenv extra due to pypa/build#266
 	build[virtualenv]
+	jaraco.context
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
This enables distribution packagers to build doc packages offline. (See #7, #10, avoids build's unableness to build isolated in offline mode https://github.com/pypa/build/issues/556)